### PR TITLE
Correct README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ However, if you use something like Serde, you can still serialize your value obj
 class Robot {
     public function __construct(
         #[Field('height_in_centimeters')]
-        #[TimeAs(Unit::Centimeters)]
+        #[DistanceAs(Unit::Centimeters)]
         public Distance $height,
     ) {}
 }


### PR DESCRIPTION
I presume this is a copy-paste error from the time library.  Easy fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example in the README to correctly annotate the `$height` property as a distance value in centimeters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->